### PR TITLE
Add schnelLFMM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .opt
 .snakemake
-v2g_wd
+v2g_wd_sim

--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,5 @@ vcf: "ath/ath_filt-MAC5-MISS20.vcf.gz"
 workdir: "v2g_wd_sim"
 missing_threshold: 1.0
 permutations: 0
+lfmm_k: 12
 

--- a/install_binaries.sh
+++ b/install_binaries.sh
@@ -23,6 +23,10 @@ curl -LO https://github.com/shenwei356/csvtk/releases/download/v0.32.0/csvtk_lin
 tar xf csvtk_linux_amd64.tar.gz
 mv csvtk ../bin/
 
+curl -LO https://github.com/kdm9/schnelLFMM/releases/download/v0.2.1/schnellfmm-linux-x86_64.tar.gz
+tar xf schnellfmm-linux-x86_64.tar.gz
+mv schnellfmm ../bin/
+
 cd ..
 rm -rf tmp
 ls bin

--- a/scripts/plot_lfmm.R
+++ b/scripts/plot_lfmm.R
@@ -1,0 +1,39 @@
+#!/usr/bin/env Rscript
+library(argparser, quietly=TRUE)
+
+ap = arg_parser("Plot a schnelLFMM result")
+
+ap = add_argument(ap, "assoc_file", help=".tsv file from a schnelLFMM run")
+ap = add_argument(ap, "--pval", help="Which phenotype p-value column to use", default="p_ath_sim_h50")
+ap = add_argument(ap, "--output", help="Output file")
+ap = add_argument(ap, "--highlight-snps", help="highlighted snp file")
+
+args = parse_args(ap)
+
+if (is.na(args$output)) {
+    args$output = paste0(args$assoc_file, ".plot.png")
+}
+
+str(args)
+
+library(readr)
+library(dplyr)
+library(ggplot2)
+
+highlighted = c()
+if (!is.na(args$highlight_snps)) {
+    highlighted = read_tsv(args$highlight_snps) %>%
+        pull(1)
+    print(paste("Highlighting", length(highlighted), "SNPs"))
+}
+
+gwas = read_tsv(args$assoc_file) %>%
+    rename(pval={!!args$pval}, rs=snp_id, ps=pos) %>%
+    mutate(highlight=rs %in% highlighted) %>%
+    arrange(highlight, chr, ps) %>%
+    glimpse()
+p = ggplot(gwas, aes(x=ps, y=-log10(pval))) +
+    geom_point(aes(colour=highlight)) +
+    facet_grid(~chr, scales="free_x", space="free_x") +
+    theme_bw()
+ggsave(args$output, plot=p, dpi=600, width=8, height=4)

--- a/vcf2gwas.snk
+++ b/vcf2gwas.snk
@@ -117,8 +117,10 @@ rule all:
         WD("tmp/genotypes"),
         WD("tmp/grm.cXX.txt"),
         expand(WD("out/{pheno}.assoc.txt"), pheno=PHENOS),
-        expand(WD("out/{pheno}.manhattan.png"), pheno=PHENOS),
+        expand(WD("out/gemma_{pheno}.manhattan.png"), pheno=PHENOS),
+        expand(WD("out/lfmm_{pheno}.manhattan.png"), pheno=PHENOS),
         WD("out/trait_pves.tsv"),
+        WD("out/lfmm2_out.tsv"),
 
 rule plinksubsetfile:
     output:
@@ -206,13 +208,42 @@ rule lmm:
         "   -n {params.phenoi}"
         ") >{output.log} 2>&1"
 
-rule plotr:
+rule lfmm:
+    input:
+        bfile=WD("tmp/genotypes.bed"),
+        fam=WD("tmp/genotypes.fam"),
+        pheno=config["phenotypes"]
+    output:
+        stats=WD("out/lfmm2_out.tsv"),
+        summary=WD("out/lfmm2_out.summary.txt")
+    params:
+        k=config.get("lfmm_k", 12),
+        dir=lambda wc, input, output: Path(output.stats).parent
+    shell:
+        "schnellfmm"
+        "   -b {input.bfile}"
+        "   -c {input.pheno}"
+        "   -k {params.k}"
+        "   -o {params.dir}/lfmm2_out"
+
+rule plot_gemma:
     input:
         assoc=WD("out/{pheno}.assoc.txt"),
     output:
-        assoc=WD("out/{pheno}.manhattan.png"),
+        WD("out/gemma_{pheno}.manhattan.png"),
     shell:
         "Rscript scripts/plot_gemma.R --output {output} {input}"
+        
+rule plot_lfmm:
+    input:
+        assoc=WD("out/lfmm2_out.tsv"),
+    output:
+        WD("out/lfmm_{pheno}.manhattan.png"),
+    shell:
+        "Rscript scripts/plot_lfmm.R"
+        "   --pval p_{wildcards.pheno}"
+        "   --output {output}"
+        "   {input}"
 
 rule heritability_table:
     input:


### PR DESCRIPTION
Adds schnelLFMM as a second association method alongside GEMMA.

- New `lfmm` rule takes the plink bed and phenotype file, runs schnelLFMM, outputs per-run TSV and summary
- New `plot_lfmm` rule produces per-phenotype Manhattan plots mirroring the GEMMA plot output
- Renamed GEMMA plot outputs to `gemma_{pheno}.manhattan.png` for clarity
- Install script updated to build schnelLFMM from source via cargo (required on systems with older glibc)
- Tested on the `ath` example data -- produces outputs and the chromosome 4 signal looks consistent between methods

Not 100% sure I've done everything the way you'd want it -- happy to revise.